### PR TITLE
jQuery multiple-element action fix

### DIFF
--- a/pixastic.jquery.js
+++ b/pixastic.jquery.js
@@ -9,13 +9,14 @@ if (typeof jQuery != "undefined" && jQuery && jQuery.fn) {
 		var newElements = [];
 		this.each(
 			function () {
+				var newOptions = jQuery.extend({}, options);
 				if (this.tagName.toLowerCase() == "img" && !this.complete) {
 					return;
 				}
 				if (action === "revert") {
 					var res = Pixastic.revert(this);
 				} else {
-					var res = Pixastic.process(this, action, options);
+					var res = Pixastic.process(this, action, newOptions);
 				}
 				if (res) {
 					newElements.push(res);


### PR DESCRIPTION
The JQuery plugin wasn't making a copy of its input options, and since
Pixastic.process modifies the options object, the re-use of options was
the same pixastic action to be applied to the first image/canvas.

To address this, use jQuery.extend() to make a copy of the original
options for each element and pass it to Pixastic.process
