### PR TITLE
 Allow pixastic.worker.control.js to be in a different location

### DIFF
--- a/pixastic.js
+++ b/pixastic.js
@@ -21,17 +21,18 @@
         }
     }
     
-    function Pixastic(ctx) {
+    function Pixastic(ctx, workerControlPath) {
 
         var P = {},
             width = ctx.canvas.width, 
             height = ctx.canvas.height,
-            queue = [];
-            
+            queue = [],
+            workerControlPath = workerControlPath || "";
+
         if (!worker) {
             if (typeof window.Worker != "undefined") {
                 try {
-                    worker = new window.Worker("pixastic.worker.control.js");
+                    worker = new window.Worker(workerControlPath + "pixastic.worker.control.js");
                 } catch(e) {
                     if (location.protocol == "file:") {
                         Pixastic.log("Could not create real worker, running from file://")


### PR DESCRIPTION
When integrating pixastic into other applications it would be handy to allow the worker control file to be saved in a different directory, right now it is hard coded to be in the same directory as the other pixastic files.
