### PR TITLE
Image Dimensions Fix

### DIFF
--- a/pixastic.core.js
+++ b/pixastic.core.js
@@ -217,7 +217,7 @@ var Pixastic = (function() {
 			var w = img.offsetWidth;
 			var h = img.offsetHeight;
 
-			if (imageIsCanvas) {
+			if (imageIsCanvas || (img.width && img.height)) {
 				w = img.width;
 				h = img.height;
 			}


### PR DESCRIPTION
If the image has a valid width and height, use it. Otherwise, the
off-screen rendering creates an image that is the maximum size of the
browser window. This can be seen on with large images that are greater
than the size of the browser window.
